### PR TITLE
Ja ticket3

### DIFF
--- a/SQLQuery1.sql
+++ b/SQLQuery1.sql
@@ -1,0 +1,13 @@
+﻿ SELECT p.Id, p.Title, p.Content, 
+                              p.ImageLocation AS HeaderImage,
+                              p.CreateDateTime, p.PublishDateTime, p.IsApproved,
+                              p.CategoryId, p.UserProfileId,
+                              c.[Name] AS CategoryName,
+                              u.FirstName, u.LastName, u.DisplayName, 
+                              u.Email, u.CreateDateTime, u.ImageLocation AS AvatarImage,
+                              u.UserTypeId, 
+                              ut.[Name] AS UserTypeName
+                         FROM Post p
+                              LEFT JOIN Category c ON p.CategoryId = c.id
+                              LEFT JOIN UserProfile u ON p.UserProfileId = u.id
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id

--- a/Tabloid/Controllers/PostController.cs
+++ b/Tabloid/Controllers/PostController.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Tabloid.Repositories;
+using Tabloid.Models;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace Tabloid.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PostController : ControllerBase
+    {
+        private readonly IPostRepository _postRepository;
+        public PostController(IPostRepository postRepository)
+        {
+            _postRepository = postRepository;
+        }
+
+        // GET: api/<PostController>
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok(_postRepository.GetAll());
+        }
+
+        // GET api/<PostController>/5
+        [HttpGet("{id}")]
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/<PostController>
+        [HttpPost]
+        public void Post([FromBody] string value)
+        {
+        }
+
+        // PUT api/<PostController>/5
+        [HttpPut("{id}")]
+        public void Put(int id, [FromBody] string value)
+        {
+        }
+
+        // DELETE api/<PostController>/5
+        [HttpDelete("{id}")]
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/Tabloid/Models/Post.cs
+++ b/Tabloid/Models/Post.cs
@@ -23,5 +23,10 @@ namespace Tabloid.Models
 
         public UserProfile UserProfile { get; set; }
 
+        [Required]
+        public int CategoryId { get; set; }
+
+        public Category Category { get; set; }
+
     }
 }

--- a/Tabloid/Models/Post.cs
+++ b/Tabloid/Models/Post.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Xml.Linq;
+using System;
+
+namespace Tabloid.Models
+{
+    public class Post
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Title { get; set; }
+
+        [Required]
+        public string ImageLocation { get; set; }
+
+        [Required]
+        public DateTime CreateDateTime{ get; set; }
+
+        [Required]
+        public int UserProfileId { get; set; }
+
+        public UserProfile UserProfile { get; set; }
+
+    }
+}

--- a/Tabloid/Repositories/IPostRepository.cs
+++ b/Tabloid/Repositories/IPostRepository.cs
@@ -6,7 +6,7 @@ namespace Tabloid.Repositories
 {
     public interface IPostRepository
     {
-        List<Post> GetAll();
+       public List<Post> GetAll();
 
     }
 }

--- a/Tabloid/Repositories/IPostRepository.cs
+++ b/Tabloid/Repositories/IPostRepository.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System;
+using Tabloid.Models;
+
+namespace Tabloid.Repositories
+{
+    public interface IPostRepository
+    {
+        List<Post> GetAll();
+
+    }
+}

--- a/Tabloid/Repositories/PostRepository.cs
+++ b/Tabloid/Repositories/PostRepository.cs
@@ -2,8 +2,12 @@
 using System.Linq;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Data.SqlClient;
 using Tabloid.Models;
 using Tabloid.Utils;
+using Tabloid.Repositories;
+using Microsoft.Extensions.Hosting;
+using System.Reflection.PortableExecutable;
 
 namespace Tabloid.Repositories
 {
@@ -20,45 +24,83 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"
                 SELECT p.Id AS PostId, p.Title, p.CreateDateTime AS PostDateCreated, 
-                       p.ImageLocation AS PostImageUrl, p.UserProfileId,
+                       p.ImageLocation AS PostImageUrl, p.CategoryId, p.UserProfileId, 
 
                        up.FirstName, up.LastName, up.Email, up.CreateDateTime AS UserProfileDateCreated, 
-                       up.ImageLocation AS UserProfileImageUrl
+                       up.ImageLocation AS UserProfileImageUrl,
+
+                        c.[Name] AS CategoryName
                   FROM Post p 
                        LEFT JOIN UserProfile up ON p.UserProfileId = up.id
-              ORDER BY p.CreateDateTime";
+                       LEFT JOIN Category c ON p.CategoryId = c.id               
+                    WHERE IsApproved = 1 AND PublishDateTime<SYSDATETIME()
+                    ORDER BY p.PublishDateTime DESC";
 
                     var reader = cmd.ExecuteReader();
 
                     var posts = new List<Post>();
                     while (reader.Read())
                     {
-                        posts.Add(new Post()
-                        {
-                            Id = DbUtils.GetInt(reader, "PostId"),
-                            Title = DbUtils.GetString(reader, "Title"),
-                            CreateDateTime = DbUtils.GetDateTime(reader, "PostDateCreated"),
-                            ImageLocation = DbUtils.GetString(reader, "PostImageUrl"),
-                            UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
-                            UserProfile = new UserProfile()
+                      
+                            posts.Add(new Post()
                             {
-                                Id = DbUtils.GetInt(reader, "UserProfileId"),
-                                FirstName = DbUtils.GetString(reader, "FirstName"),
-                                LastName = DbUtils.GetString(reader, "LastName"),
-                                Email = DbUtils.GetString(reader, "Email"),
-                                CreateDateTime= DbUtils.GetDateTime(reader, "UserProfileDateCreated"),
-                                ImageLocation = DbUtils.GetString(reader, "UserProfileImageUrl"),
-                            },
-                        });
-                    }
+                                Id = DbUtils.GetInt(reader, "PostId"),
+                                Title = DbUtils.GetString(reader, "Title"),
+                                CreateDateTime = DbUtils.GetDateTime(reader, "PostDateCreated"),
+                                ImageLocation = DbUtils.GetString(reader, "PostImageUrl"),
+                                UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
+                                UserProfile = new UserProfile()
+                                {
+                                    Id = DbUtils.GetInt(reader, "UserProfileId"),                                    
+                                    FirstName = DbUtils.GetString(reader, "FirstName"),
+                                    LastName = DbUtils.GetString(reader, "LastName"),
+                                    Email = DbUtils.GetString(reader, "Email"),
+                                    CreateDateTime = DbUtils.GetDateTime(reader, "UserProfileDateCreated"),
+                                    ImageLocation = DbUtils.GetString(reader, "UserProfileImageUrl"),
+                                },
+                                CategoryId = DbUtils.GetInt(reader, "CategoryId"),
+                                Category = new Category()
+                                {
+                                    Id = DbUtils.GetInt(reader, "CategoryId"),
+                                    Name = DbUtils.GetString(reader, "CategoryName"),
+                                },
+                            });
+                       }
 
-                    reader.Close();
+                        reader.Close();
 
-                    return posts;
+                        return posts;
+                    } 
                 }
             }
         }
-
-
     }
-}
+
+//while (reader.Read())
+//{
+
+//    posts.Add(new Post()
+//    {
+//        Id = DbUtils.GetInt(reader, "PostId"),
+//        Title = DbUtils.GetString(reader, "Title"),
+//        CreateDateTime = DbUtils.GetDateTime(reader, "PostDateCreated"),
+//        ImageLocation = DbUtils.GetString(reader, "PostImageUrl"),
+//        UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
+//        UserProfile = new UserProfile()
+//        {
+//            Id = DbUtils.GetInt(reader, "UserProfileId"),
+//            DisplayName = DbUtils.GetString(reader, "DisplayName"),
+//            FirstName = DbUtils.GetString(reader, "FirstName"),
+//            LastName = DbUtils.GetString(reader, "LastName"),
+//            Email = DbUtils.GetString(reader, "Email"),
+//            CreateDateTime = DbUtils.GetDateTime(reader, "UserProfileDateCreated"),
+//            ImageLocation = DbUtils.GetString(reader, "UserProfileImageUrl"),
+//        },
+//        CategoryId = DbUtils.GetInt(reader, "CategoryId"),
+//        Category = new Category()
+//        {
+//            Id = DbUtils.GetInt(reader, "CategoryId"),
+//            Name = DbUtils.GetString(reader, "CategoryName"),
+//        },
+//    });
+//}

--- a/Tabloid/Repositories/PostRepository.cs
+++ b/Tabloid/Repositories/PostRepository.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Tabloid.Models;
+using Tabloid.Utils;
+
+namespace Tabloid.Repositories
+{
+    public class PostRepository : BaseRepository, IPostRepository
+    {
+        public PostRepository(IConfiguration configuration) : base(configuration) { }
+
+        public List<Post> GetAll()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                SELECT p.Id AS PostId, p.Title, p.CreateDateTime AS PostDateCreated, 
+                       p.ImageLocation AS PostImageUrl, p.UserProfileId,
+
+                       up.FirstName, up.LastName, up.Email, up.CreateDateTime AS UserProfileDateCreated, 
+                       up.ImageLocation AS UserProfileImageUrl
+                  FROM Post p 
+                       LEFT JOIN UserProfile up ON p.UserProfileId = up.id
+              ORDER BY p.CreateDateTime";
+
+                    var reader = cmd.ExecuteReader();
+
+                    var posts = new List<Post>();
+                    while (reader.Read())
+                    {
+                        posts.Add(new Post()
+                        {
+                            Id = DbUtils.GetInt(reader, "PostId"),
+                            Title = DbUtils.GetString(reader, "Title"),
+                            CreateDateTime = DbUtils.GetDateTime(reader, "PostDateCreated"),
+                            ImageLocation = DbUtils.GetString(reader, "PostImageUrl"),
+                            UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
+                            UserProfile = new UserProfile()
+                            {
+                                Id = DbUtils.GetInt(reader, "UserProfileId"),
+                                FirstName = DbUtils.GetString(reader, "FirstName"),
+                                LastName = DbUtils.GetString(reader, "LastName"),
+                                Email = DbUtils.GetString(reader, "Email"),
+                                CreateDateTime= DbUtils.GetDateTime(reader, "UserProfileDateCreated"),
+                                ImageLocation = DbUtils.GetString(reader, "UserProfileImageUrl"),
+                            },
+                        });
+                    }
+
+                    reader.Close();
+
+                    return posts;
+                }
+            }
+        }
+
+
+    }
+}

--- a/Tabloid/Startup.cs
+++ b/Tabloid/Startup.cs
@@ -24,6 +24,7 @@ namespace Tabloid
         {
             services.AddTransient<IUserRepository, UserRepository>();
             services.AddTransient<ICategoryRepository, CategoryRepository>();
+            services.AddTransient<IPostRepository, PostRepository>();
 
 
             services.AddControllers();

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -3,6 +3,9 @@ import { Route, Routes } from "react-router-dom";
 import CategoryDelete from "./categories/CategoryDelete";
 import CategoryForm from "./categories/CategoryForm";
 import CategoryList from "./categories/CategoryList";
+import  PostList from "./posts/PostList";
+
+// import { Post } from "./posts/Post";
 import Hello from "./Hello";
 
 export default function ApplicationViews() {
@@ -12,7 +15,12 @@ export default function ApplicationViews() {
         <Route path="/" element={<Hello />} />
         <Route path="/categories" element={<CategoryList />} />
         <Route path="/createCategory" element={<CategoryForm />} />
-        <Route path="/deleteCategory/:id" element={<CategoryDelete />} />
+        <Route path="/deleteCategory/:id" element={<CategoryDelete />} />   
+        <Route path="/posts" element={<PostList />} />
+
+        {/* <Route path="/posts/" element={<PostList />} /> */}
+
+
       </Routes>
    );
  

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -27,7 +27,10 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
             <div style={{display: 'flex'}}>
               <NavItem>
                 <NavLink tag={RRNavLink} to="/">Home</NavLink>
-              </NavItem>
+                              </NavItem>
+              <NavItem>
+                <NavLink tag={RRNavLink} to="/posts">Posts</NavLink>
+               </NavItem>
               <NavItem>
                 <NavLink tag={RRNavLink} to="/categories">Category Management</NavLink>
               </NavItem>

--- a/Tabloid/client/src/components/posts/Post.js
+++ b/Tabloid/client/src/components/posts/Post.js
@@ -12,9 +12,20 @@ import { useParams } from "react-router-dom"
   
 
     return (
-        <div style={{display:'flex', letterSpacing: '.5px', alignItems: 'center', margin: '15px', borderBottom: '1px solid gray', height: '30px', width: '500px', justifyContent: 'space-between'}}>
-            <h5 style={{ marginRight: '15px' }}>{post.title}{post.title}{post.title}</h5>
-        </div>
+        // <div style={{display:'flex', letterSpacing: '.5px', alignItems: 'center', margin: '15px', flexDirection: "column", borderBottom: '1px solid gray', height: '30px', width: '500px', justifyContent: 'space-between'}}>
+        //     <h5 style={{ marginRight: '15px' }}>{post.title}    {post.userProfile.firstName}   {post.userProfile.lastName}  {post.category.name}</h5>            
+        // </div>
+        
+        <div style={{display:'flex', letterSpacing: '.5px', alignItems: 'center', margin: '15px', flexDirection: "row", borderBottom: '1px solid gray', height: '30px', width: '500px', justifyContent: 'space-between'}}>
+
+
+
+        <strong>{post.title}</strong>
+        <p>Author: {post.userProfile.firstName}   {post.userProfile.lastName}</p>
+        <p>Category: {post.category.name}</p>               
+    </div>
+
+
     )
 }
 

--- a/Tabloid/client/src/components/posts/Post.js
+++ b/Tabloid/client/src/components/posts/Post.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Card, CardBody, CardTitle } from "reactstrap";
+import { useParams } from "react-router-dom"
+
+   export const Post = ({post}) =>{
+
+    const {id} = useParams()    
+    const navigate = useNavigate()
+
+  
+
+    return (
+        <div style={{display:'flex', letterSpacing: '.5px', alignItems: 'center', margin: '15px', borderBottom: '1px solid gray', height: '30px', width: '500px', justifyContent: 'space-between'}}>
+            <h5 style={{ marginRight: '15px' }}>{post.title}{post.title}{post.title}</h5>
+        </div>
+    )
+}
+
+export default Post;

--- a/Tabloid/client/src/components/posts/PostList.js
+++ b/Tabloid/client/src/components/posts/PostList.js
@@ -1,0 +1,37 @@
+import React, {useState, useEffect} from "react";
+import { useNavigate } from "react-router-dom";
+import {Post} from "./Post"
+import { getAllPosts, getById } from "./PostManager";
+
+const PostList = () => {
+    const [posts, setPosts] = useState([]);
+
+   
+    const navigate = useNavigate();
+
+    const getPosts = () => {
+        getAllPosts().then( all => setPosts(all))
+    };
+    useEffect(() => {
+        getPosts();
+    }, []);
+
+    
+    return (
+      <div className="container">
+        <div className="row justify-content-center" style={{display: 'flex', flexDirection: 'column'}}>
+          <h4 style={{marginTop: '20px', marginBottom: '15px'}}>Posts</h4>
+          
+            <div className="cards-column">
+                {posts.map((p) => (
+                  <div style={{display: 'flex'}}>
+                    <Post key={p.id} post={p} />                   
+                    </div>
+                    ))}
+        </div>
+      </div>
+    </div>
+    )
+}
+
+export default PostList;

--- a/Tabloid/client/src/components/posts/PostList.js
+++ b/Tabloid/client/src/components/posts/PostList.js
@@ -21,7 +21,7 @@ const PostList = () => {
       <div className="container">
         <div className="row justify-content-center" style={{display: 'flex', flexDirection: 'column'}}>
           <h4 style={{marginTop: '20px', marginBottom: '15px'}}>Posts</h4>
-          
+          {/* <strong>Title</strong><strong>Author</strong><strong>Category</strong> */}
             <div className="cards-column">
                 {posts.map((p) => (
                   <div style={{display: 'flex'}}>

--- a/Tabloid/client/src/components/posts/PostManager.js
+++ b/Tabloid/client/src/components/posts/PostManager.js
@@ -1,0 +1,9 @@
+// import React from "react";
+
+// const baseUrl = '/api/post';
+
+export const getAllPosts = () => {
+    return fetch(`https://localhost:5001/api/Post`)
+    .then((res) => res.json())
+};
+


### PR DESCRIPTION
Trello Ticket: [#3 - ](https://trello.com/c/AB14rRIr/12-12-edit-a-category)View all Posts

Created code to allow a logged in user to view a list of all the Posts
  
Testing Instructions:
git add and git commit whatever you're working on on your branch
git checkout main
git fetch --a
git checkout ja-ticket3
If you don't see the most recent version of my files, git pull origin ja-ticket3
If you haven't created the Tabloid database, please do so.
7. Use this data to fill out tables and columns: [SQL data](https://github.com/NewForce-Cohort-6/tabloidfullstack-mac-cheese/blob/main/SQL/01_Tabloid_Create_DB.sql)
8. Click the execute with debugger solid green button to launch the app
9. Select the Posts menu option
10. You should be directed to the Posts list page
11. Each post in the list should display the title, author and category
12. The list should ONLY contain approved Posts
13. The list should ONLY contain Posts with a publication date that is in the past
14. The list should be in order of publication date with the most recent on top
(List of should include the following):
grow frictionless e-tailers
Author: Giuseppe Teanby
Category: Politics
 
productize turn-key convergence
Author: Giuseppe Teanby
Category: Technology
 
streamline sticky e-commerce
Author: Emmaline Cornfoot
Category: Cooking
 
benchmark web-enabled markets
Author: Cristabel Van Der Weedenburg
Category: Music
 
transition next-generation networks
Author: Giuseppe Teanby
Category: Science
 
morph turn-key e-commerce
Author: Rosana Yakushkev
Category: Cooking
 
drive front-end portals
Author: Arnold Otton
Category: Cooking
 
synthesize transparent niches
Author: Aharon Grzeskowski
Category: Science
 
deploy magnetic metrics
Author: Aharon Grzeskowski
Category: Cooking
 
architect next-generation e-business
Author: Reina Sandwith
Category: Music
 
streamline virtual web-readiness
Author: Arnold Otton
Category: Politics
 
visualize killer systems
Author: Aharon Grzeskowski
Category: Science
 
orchestrate value-added communities
Author: Arnold Otton
Category: Cooking
 
synergize seamless supply-chains
Author: Arnold Otton
Category: Cooking
 
monetize visionary platforms
Author: Tobi Figiovanni
Category: Science
 
morph front-end markets
Author: Rosana Yakushkev
Category: Science
 
incubate mission-critical channels
Author: Giuseppe Teanby
Category: Technology
 
innovate cross-platform supply-chains
Author: Emmaline Cornfoot
Category: Technology
 
innovate strategic convergence
Author: Tobi Figiovanni
Category: Science
 
incubate collaborative e-commerce
Author: Rosana Yakushkev
Category: Cooking
 
incentivize virtual models
Author: Cristabel Van Der Weedenburg
Category: Music
 
target bleeding-edge architectures
Author: Aharon Grzeskowski
Category: Science
 
evolve sticky web-readiness
Author: Giuseppe Teanby
Category: Technology
 
exploit e-business e-services
Author: Tobi Figiovanni
Category: Cooking
streamline cross-platform web services
Author: Cristabel Van Der Weedenburg
Category: Science
 
 **NOTE:** For the time being it is acceptable to treat all users as `admin` users. There is a future story about enforcing user permissions.(https://github.com/NewForce-Cohort-6/tabloidmvc-the-bit-o-honeys/blob/main/SQL/01_TabloidMVC_Create_DB.sql)
15. Use this to seed the database : [SQL SEED DATA](https://github.com/NewForce-Cohort-6/tabloidmvc-the-tootsie-rolls/blob/main/SQL/02_TabloidMVC_Seed_Data.sql)
9, Click the execute with debugger solid green button to launch the app
10, When they select the Posts menu option
Then they should be directed to the Posts list page
And each post in the list should display the title, author and category
And the list should ONLY contain approved Posts
And the list should ONLY contain Posts with a publication date that is in the past
And the list should be in order of publication date with the most recent on top
(List of should include the following):
grow frictionless e-tailers
Author: Giuseppe Teanby
Category: Politics
 
productize turn-key convergence
Author: Giuseppe Teanby
Category: Technology
 
streamline sticky e-commerce
Author: Emmaline Cornfoot
Category: Cooking
 
benchmark web-enabled markets
Author: Cristabel Van Der Weedenburg
Category: Music
 
transition next-generation networks
Author: Giuseppe Teanby
Category: Science
 
morph turn-key e-commerce
Author: Rosana Yakushkev
Category: Cooking
 
drive front-end portals
Author: Arnold Otton
Category: Cooking
 
synthesize transparent niches
Author: Aharon Grzeskowski
Category: Science
 
deploy magnetic metrics
Author: Aharon Grzeskowski
Category: Cooking
 
architect next-generation e-business
Author: Reina Sandwith
Category: Music
 
streamline virtual web-readiness
Author: Arnold Otton
Category: Politics
 
visualize killer systems
Author: Aharon Grzeskowski
Category: Science
 
orchestrate value-added communities
Author: Arnold Otton
Category: Cooking
 
synergize seamless supply-chains
Author: Arnold Otton
Category: Cooking
 
monetize visionary platforms
Author: Tobi Figiovanni
Category: Science
 
morph front-end markets
Author: Rosana Yakushkev
Category: Science
 
incubate mission-critical channels
Author: Giuseppe Teanby
Category: Technology
 
innovate cross-platform supply-chains
Author: Emmaline Cornfoot
Category: Technology
 
innovate strategic convergence
Author: Tobi Figiovanni
Category: Science
 
incubate collaborative e-commerce
Author: Rosana Yakushkev
Category: Cooking
 
incentivize virtual models
Author: Cristabel Van Der Weedenburg
Category: Music
 
target bleeding-edge architectures
Author: Aharon Grzeskowski
Category: Science
 
evolve sticky web-readiness
Author: Giuseppe Teanby
Category: Technology
 
exploit e-business e-services
Author: Tobi Figiovanni
Category: Cooking

streamline cross-platform web services
Author: Cristabel Van Der Weedenburg
Category: Science
 
 **NOTE:** For the time being it is acceptable to treat all users as `admin` users. There is a future story about enforcing user permissions.